### PR TITLE
make the configuration specific to test environment

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,20 +1,24 @@
 {
-  "presets": [
-    // we import this so we can use jsx in our tests, 
-    // it is not essential for the async/await workaround
-    "@babel/preset-react"
-  ],
-  "plugins": [
-    // this plugin converts async/await syntax into 
-    // regular function calls to a library called 'regenerator'
-    "@babel/plugin-transform-regenerator", 
+  "env": {
+    "test": {
+      "presets": [
+        // we import this so we can use jsx in our tests, 
+        // it is not essential for the async/await workaround
+        "@babel/preset-react"
+      ],
+      "plugins": [
+        // this plugin converts async/await syntax into 
+        // regular function calls to a library called 'regenerator'
+        "@babel/plugin-transform-regenerator", 
 
-    // this plugin automatically imports the regenerator runtime when needed 
-    [ "@babel/plugin-transform-runtime", {regenerator: true} ],
-    
-    // this plugin converts es6 `import`/`export` syntax to `require(...)` calls 
-    "@babel/plugin-transform-modules-commonjs"
-  ]
+        // this plugin automatically imports the regenerator runtime when needed 
+        [ "@babel/plugin-transform-runtime", {regenerator: true} ],
+
+        // this plugin converts es6 `import`/`export` syntax to `require(...)` calls 
+        "@babel/plugin-transform-modules-commonjs"
+      ]
+    }
+  }
 }
 
 // you should also add `@babel/runtime` to your package.json dependencies


### PR DESCRIPTION
This makes .babelrc test-specific, so that we don't infect our regular async/await with the regenerator runtime